### PR TITLE
Add C++11 compatibility fixes

### DIFF
--- a/src/bms.hpp
+++ b/src/bms.hpp
@@ -135,7 +135,7 @@ class BMS {
   vector<bool> Pnil;
   bool fixalpha;
 
-  static const double g=2.0;
+  static constexpr double g=2.0;
   gsl_rng ** rg;
   int max_threads;
 

--- a/src/hitsio.cpp
+++ b/src/hitsio.cpp
@@ -343,7 +343,7 @@ bool HitsfileReader::readReadMapRecordReadIDSchema0(string &readID) {
 
 bool HitsfileReader::readReadMapRecordTranscriptIDSchema0(string &transcriptID) {
 	if ((ifs.eof()) || (ifs.peek() == '>')) { return false; }
-	return(getline(ifs, transcriptID));
+	return(static_cast<bool>(getline(ifs, transcriptID)));
 }
 
 void HitsfileReader::readHeaderSchema1(vector<string> *transcriptName, map<string, double> *transcriptEffectiveLength,


### PR DESCRIPTION
These are two fixes for building with GCC6 (as used in Fedora Rawhide), which is stricter about C++11 compliance.