### PR TITLE
Enable Travis CI (Continuous Integration) with Ubuntu and Fedora.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+dist: bionic
+matrix:
+  include:
+    - name: ubuntu
+      language: cpp
+      compiler: gcc
+      install:
+        - |
+          travis_retry sudo apt-get install \
+            gfortran \
+            libboost-all-dev \
+            libgsl-dev \
+            libhts-dev \
+            libarmadillo-dev
+      script:
+        - ./test.sh
+    - name: fedora
+      language: minimal
+      services: docker
+      install:
+        - travis_retry docker build --rm -t mmseq -f Dockerfile-fedora .
+      script:
+        - docker run --rm -t mmseq ./test.sh
+  allow_failures:
+  fast_finish: true

--- a/Dockerfile-fedora
+++ b/Dockerfile-fedora
@@ -1,0 +1,19 @@
+FROM fedora:30
+
+RUN dnf -y upgrade \
+  && dnf -y install \
+  --setopt=tsflags=nodocs \
+  # Build dependency
+  armadillo-devel \
+  boost-devel \
+  gcc-c++ \
+  gsl-devel \
+  htslib-devel \
+  make \
+  zlib-devel \
+  # Testing dependency
+  git-core \
+  && dnf clean all
+
+WORKDIR /work
+COPY . .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MMSEQ: Transcript and gene level expression analysis using multi-mapping RNA-seq reads
 
+[![Build Status](https://travis-ci.org/eturro/mmseq.svg?branch=master)](https://travis-ci.org/eturro/mmseq)
+
 ![mmseq collage](https://raw.github.com/eturro/mmseq/master/doc/mmseq-collage.png)
 
 ## What is MMSEQ?

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+pushd src
+make clean
+make
+popd


### PR DESCRIPTION
Hi,
I like to suggest enabling Travis CI (Continuous Integration) for this repository.
So, I prepared it.

Travis CI is for example used in samtools project.
https://github.com/samtools/samtools

The merits are 
* I see the document `src/dependencies.md`. And we can show the actual used dependencies with code.
* You can check if your code is valid for each code and each pull-request, and cron mode.
* The CI provides reproductive ways to build mmseq to users.

Here is the CI result of my forked repository.
https://travis-ci.org/junaruga/mmseq/builds/606249838
You can also see the build status badge on `README.md`.
https://github.com/junaruga/mmseq/blob/feature/add-ci/README.md

I selected 2 cases for now.

* Ubuntu that is Travis CI's host environment and represents Ubuntu/Debian/etc environments
* Fedora that represents Fedora/CentOS/Red Hat/etc environments.

The modification for `src/bms.hpp` to fix following compile error.

```
In file included from bms.cpp:21:
bms.hpp:139:23: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double BMS::g’ of non-integral type [-fpermissive]
  139 |   static const double g=2.0;
```

To enable Travis CI for this repository, access following URL, and login with your GitHub account, and enable it.
https://travis-ci.org/eturro/mmseq

How do you think? I think this CI helps maintaining this repository.
Thank you.