### PR TITLE
Convert mmseq to use the HTSlib API instead of the legacy samtools API

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ The [MMSEQ package](#installation) comes with statically-linked binaries for 64-
 - [Boost C++ libraries](http://boost.org/)
 - [GNU Scientific Library](http://www.gnu.org/software/gsl)
 - [Armadillo C++ linear algebra library](http://arma.sf.net) (with [lapack](http://www.netlib.org/lapack) and [blas](http://www.netlib.org/blas))
-- [SAMtools library](http://samtools.sourceforge.net/)
+- [HTSlib library](http://htslib.org/)
 
 Then clone the GitHub repository and run `make` from the `src` directory, which will place the binaries in the `bin` directory:
 

--- a/src/dependencies.md
+++ b/src/dependencies.md
@@ -12,8 +12,8 @@
   - Fedora/CentOS/Red Hat/etc: `yum install gsl`
 - [Armadillo C++ linear algebra library](http://arma.sf.net)
   - Mac OS X+[Homebrew](http://brew.sh/): `brew install homebrew/science/openblas; brew install homebrew/dupes/lapack; brew install armadillo`
-- [SAMtools library](http://samtools.sourceforge.net/)
-  - Mac OS X+[Homebrew](http://brew.sh/): `brew install samtools; export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/local/include/bam`
+- [HTSlib library](http://htslib.org/)
+  - Mac OS X+[Homebrew](http://brew.sh/): `brew install htslib`
 
 Note that due to a lack of OpenMP support in Apple's clang compiler (as of El Capitan), the Mac binaries will be single-threaded.
 


### PR DESCRIPTION
For your consideration, this pull request converts _bam2hits.cpp_ to use HTSlib for its BAM-reading needs rather than the old samtools 0.1.x API. The old API has been unmaintained for many years and this conversion means that the mmseq code will need only HTSlib, not HTSlib and Samtools. Because all the legacy API functions used happened to be macros or inline, the _Makefile_ was already only linking against `-lhts` (not `-lbam`), so with this change you no longer need the legacy headers from Samtools either.

Accordingly this PR updates the instructions in _README.md_ and _dependencies.md_ to mention only HTSlib. As HTSlib's installation conventions are more mature than the legacy Samtools API's ever were, there is no longer any need to set `CPLUS_INCLUDE_PATH`.

This compiles against just HTSlib, but I have not tested it in depth.
