### PR TITLE
Add shebang to usage.sh

### DIFF
--- a/bin/usage.sh
+++ b/bin/usage.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 for c in bam2hits hitstools mmseq mmdiff mmcollapse extract_transcripts t2g_hits 'fastagrep.sh -h' testregexp.rb filterGTF.rb haploref.rb ensembl_gtf_to_gff.pl; do
   echo '`'$c'`' | sed -e 's/ -h//'
   echo ""


### PR DESCRIPTION
This PR is for small improvement.

There is a mmseq RPM package based on this repository's source code here.
https://src.fedoraproject.org/rpms/mmseq

I found the issue by the program to verify each file in the source when I trying to update it.

```
mmseq.x86_64: E: script-without-shebang /usr/bin/usage.sh
This text file has executable bits set or is located in a path dedicated for 
executables, but lacks a shebang and cannot thus be executed.  If the file is
meant to be an executable script, add the shebang, otherwise remove the 
executable bits or move the file elsewhere.
```

This message means that `usage.sh` has executable bits set, but lacks a shebang and cannot thus be executed. And this situation can be improved.

See shebang https://en.wikipedia.org/wiki/Shebang_(Unix) for detail.
